### PR TITLE
Fix setup flow, reminders, and allocation rounding

### DIFF
--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from .config import settings
 from .db import engine, Base
 from .handlers import (
     start, setup_start, setup_adv_day, setup_sal_day, setup_min, setup_max, setup_risk,
-    on_text, setup2, income, contrib, status, risk
+    setup_cancel, on_text, setup2, income, contrib, status, risk
 )
 from .scheduler import setup_jobs
 from .handlers import ADV_DAY, SAL_DAY, MIN_AMT, MAX_AMT, RISK as RISK_STATE
@@ -22,7 +22,7 @@ def build_app() -> Application:
             MAX_AMT: [MessageHandler(filters.TEXT & ~filters.COMMAND, setup_max)],
             RISK_STATE: [MessageHandler(filters.TEXT & ~filters.COMMAND, setup_risk)],
         },
-        fallbacks=[]
+        fallbacks=[CommandHandler("cancel", setup_cancel)]
     ))
 
     # Совместимость старых команд

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Float, Boolean
+from sqlalchemy import Column, Integer, String, Date, Float
 from .db import Base
 
 class User(Base):
@@ -9,7 +9,6 @@ class User(Base):
     min_contrib = Column(Integer, default=40000)
     max_contrib = Column(Integer, default=50000)
     risk = Column(String, default="balanced")
-    got_salary = Column(Boolean, default=False)
 
 class Contribution(Base):
     __tablename__ = "contribs"

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -11,16 +11,16 @@ def setup_jobs(app: Application, tz: str):
 
     @sch.scheduled_job(CronTrigger(hour=10, minute=0))
     async def ping_income_days():
-        today = datetime.now().day
+        today = datetime.now(sch.timezone).day
         with SessionLocal() as s:
             users = s.query(User).all()
             for u in users:
                 if today in (u.advance_day, u.salary_day):
                     await app.bot.send_message(
                         u.user_id,
-                        "Сегодня день выплаты (аванс/зарплата). Получил доход? Ответь:\n"
-                        "/income salary <сумма>  или  /income advance <сумма>\n"
-                        "После — внеси любую часть: /contrib <сумма>."
+                        "Сегодня день выплаты (аванс/зарплата). Получил доход?"
+                        " Открой бот, нажми «Внести взнос» и введи сумму — я предложу распределение."
+                        " Если параметры поменялись, запусти /setup."
                     )
 
     @sch.scheduled_job(CronTrigger(day="15", hour=11, minute=0))
@@ -29,8 +29,12 @@ def setup_jobs(app: Application, tz: str):
             users = s.query(User).all()
             for u in users:
                 target, plan = propose_allocation((u.min_contrib + u.max_contrib)/2, u.risk)
-                text = "Напоминание про взнос. Цель: " + target + "\n" + \
-                       "\n".join(f"- {k}: {v:,.0f} ₽".replace(",", " ") for k, v in plan.items())
+                lines = "\n".join(f"- {k}: {v:,.0f} ₽".replace(",", " ") for k, v in plan.items())
+                text = (
+                    "Напоминание про взнос. "
+                    f"Цель: {target}\n{lines}\n"
+                    "Когда будешь готов, нажми «Внести взнос» и введи сумму."
+                )
                 await app.bot.send_message(u.user_id, text)
 
     sch.start()

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -1,20 +1,35 @@
+from decimal import Decimal, ROUND_HALF_UP, ROUND_DOWN
 from .providers import get_key_rate
 
 def propose_allocation(amount: float, risk: str):
+    def normalize(alloc: dict[str, float]) -> dict[str, float]:
+        alloc = {k: max(v, 0.0) for k, v in alloc.items()}
+        total = sum(alloc.values())
+        if not total:
+            return alloc
+        return {k: v / total for k, v in alloc.items()}
+
+    def apply_rate_shift(alloc: dict[str, float], increase_key: str, decrease_key: str,
+                         kr_percent: float, baseline: float, sensitivity: float) -> dict[str, float]:
+        shift = max(min((kr_percent - baseline) * sensitivity, 0.05), -0.05)
+        alloc[increase_key] = alloc.get(increase_key, 0.0) + shift
+        alloc[decrease_key] = alloc.get(decrease_key, 0.0) - shift
+        return normalize(alloc)
+
     r = risk
     kr = get_key_rate()
+    kr_percent = kr * 100 if kr <= 1 else kr
 
     if r == "conservative":
-        # цель ~12–17%
         alloc = {
             "ОФЗ/корп облигации": 0.55,
             "Дивидендные акции РФ": 0.20,
             "Фонды денежного рынка": 0.15,
             "Золото (БПИФ)": 0.10,
         }
-        target = "≈12–17% годовых"
+        alloc = apply_rate_shift(alloc, "ОФЗ/корп облигации", "Дивидендные акции РФ", kr_percent, 11.0, 0.01)
+        target = f"≈12–17% годовых при ключевой ставке {kr_percent:.1f}%"
     elif r == "aggressive":
-        # цель ~20–25%
         alloc = {
             "Акции роста РФ/друж. рынки": 0.50,
             "Дивидендные акции РФ": 0.15,
@@ -23,9 +38,9 @@ def propose_allocation(amount: float, risk: str):
             "Корп облигации (ВДО)": 0.10,
             "Кэш/Денежный рынок": 0.05,
         }
-        target = "≈20–25% годовых"
+        alloc = apply_rate_shift(alloc, "Корп облигации (ВДО)", "Акции роста РФ/друж. рынки", kr_percent, 11.5, 0.006)
+        target = f"≈20–25% годовых при ключевой ставке {kr_percent:.1f}%"
     else:
-        # цель ~18–20%
         alloc = {
             "Акции РФ (смешанные)": 0.35,
             "Дивидендные акции": 0.20,
@@ -33,7 +48,28 @@ def propose_allocation(amount: float, risk: str):
             "Золото (БПИФ)": 0.10,
             "Крипто (BTC/ETH)": 0.10,
         }
-        target = "≈18–20% годовых"
+        alloc = apply_rate_shift(alloc, "ОФЗ/корп облигации", "Акции РФ (смешанные)", kr_percent, 11.0, 0.008)
+        target = f"≈18–20% годовых при ключевой ставке {kr_percent:.1f}%"
 
-    plan = {k: round(v * amount) for k, v in alloc.items()}
+    total_amount = int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    raw_values = [(name, Decimal(str(share)) * Decimal(total_amount)) for name, share in alloc.items()]
+    plan = {name: int(value.to_integral_value(rounding=ROUND_DOWN)) for name, value in raw_values}
+    remainder = total_amount - sum(plan.values())
+
+    if remainder > 0:
+        raw_values.sort(key=lambda x: x[1] - Decimal(plan[x[0]]), reverse=True)
+        for name, _ in raw_values:
+            if remainder <= 0:
+                break
+            plan[name] += 1
+            remainder -= 1
+    elif remainder < 0:
+        raw_values.sort(key=lambda x: x[1] - Decimal(plan[x[0]]))
+        for name, _ in raw_values:
+            if remainder >= 0:
+                break
+            if plan[name] > 0:
+                plan[name] -= 1
+                remainder += 1
+
     return target, plan


### PR DESCRIPTION
## Summary
- keep the /setup conversation in the correct step on invalid input, clear temporary data, and add a /cancel fallback
- align scheduled reminders with the button-based flow and respect the configured timezone
- update allocation calculations to react to the key rate, keep rounding consistent with the entered amount, and remove the unused got_salary field

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68d09da542d08332a4d946e501bb0c56