### PR TITLE
Fix setup flow, reminders, allocation rounding, and add balance controls

### DIFF
--- a/app/handlers.py
+++ b/app/handlers.py
@@ -1,6 +1,7 @@
 from datetime import date
+from sqlalchemy import func
 from telegram import Update, ReplyKeyboardMarkup, ReplyKeyboardRemove
-from telegram.ext import ContextTypes
+from telegram.ext import ContextTypes, ConversationHandler
 from .db import SessionLocal
 from .models import User, Contribution
 from .strategy import propose_allocation
@@ -10,6 +11,15 @@ MAIN_KB = ReplyKeyboardMarkup(
     [["Внести взнос", "Статус"], ["Сменить риск"]],
     resize_keyboard=True
 )
+
+CANCEL_BTN = "Отмена"
+RISK_CHOICES = ["conservative", "balanced", "aggressive"]
+RISK_KB = ReplyKeyboardMarkup([RISK_CHOICES, [CANCEL_BTN]], resize_keyboard=True)
+CONTRIB_KB = ReplyKeyboardMarkup([[CANCEL_BTN]], resize_keyboard=True)
+
+
+def fmt_amount(value: float) -> str:
+    return f"{value:,.0f}".replace(",", " ")
 
 # --- Состояния мастера
 ADV_DAY, SAL_DAY, MIN_AMT, MAX_AMT, RISK = range(5)
@@ -27,8 +37,9 @@ async def start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
 
 # /setup -> мастер
 async def setup_start(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    ctx.user_data.clear()
     await update.message.reply_text(
-        "Укажи день АВАНСА (число месяца 1–28):",
+        "Укажи день АВАНСА (число месяца 1–28). В любой момент можно /cancel",
         reply_markup=ReplyKeyboardRemove()
     )
     return ADV_DAY
@@ -38,7 +49,8 @@ async def setup_adv_day(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         adv = int(update.message.text)
         if not 1 <= adv <= 28: raise ValueError
     except Exception:
-        return await update.message.reply_text("Число 1–28. Введи заново.")
+        await update.message.reply_text("Число 1–28. Введи заново.")
+        return ADV_DAY
     ctx.user_data["adv"] = adv
     await update.message.reply_text("Теперь день ЗАРПЛАТЫ (1–28):")
     return SAL_DAY
@@ -48,7 +60,8 @@ async def setup_sal_day(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         sal = int(update.message.text)
         if not 1 <= sal <= 28: raise ValueError
     except Exception:
-        return await update.message.reply_text("Число 1–28. Введи заново.")
+        await update.message.reply_text("Число 1–28. Введи заново.")
+        return SAL_DAY
     ctx.user_data["sal"] = sal
     await update.message.reply_text("Минимальный ежемесячный взнос (₽):")
     return MIN_AMT
@@ -58,7 +71,8 @@ async def setup_min(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         mn = int(update.message.text)
         if mn < 0: raise ValueError
     except Exception:
-        return await update.message.reply_text("Введи целое число ≥ 0.")
+        await update.message.reply_text("Введи целое число ≥ 0.")
+        return MIN_AMT
     ctx.user_data["min"] = mn
     await update.message.reply_text("Максимальный ежемесячный взнос (₽):")
     return MAX_AMT
@@ -68,16 +82,22 @@ async def setup_max(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         mx = int(update.message.text)
         if mx <= ctx.user_data["min"]: raise ValueError
     except Exception:
-        return await update.message.reply_text("Должно быть больше минимума. Введи заново.")
+        await update.message.reply_text("Должно быть больше минимума. Введи заново.")
+        return MAX_AMT
     ctx.user_data["max"] = mx
-    kb = ReplyKeyboardMarkup([["conservative","balanced","aggressive"]], resize_keyboard=True)
+    kb = ReplyKeyboardMarkup([RISK_CHOICES], resize_keyboard=True)
     await update.message.reply_text("Выбери риск-профиль:", reply_markup=kb)
     return RISK
 
 async def setup_risk(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
     risk = update.message.text
-    if risk not in {"conservative","balanced","aggressive"}:
-        return await update.message.reply_text("Нажми одну из кнопок: conservative | balanced | aggressive")
+    if risk not in set(RISK_CHOICES):
+        kb = ReplyKeyboardMarkup([RISK_CHOICES], resize_keyboard=True)
+        await update.message.reply_text(
+            "Нажми одну из кнопок: conservative | balanced | aggressive",
+            reply_markup=kb
+        )
+        return RISK
     with SessionLocal() as s:
         u = s.get(User, update.effective_user.id) or User(user_id=update.effective_user.id)
         u.advance_day = ctx.user_data["adv"]
@@ -86,52 +106,139 @@ async def setup_risk(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
         u.max_contrib = ctx.user_data["max"]
         u.risk = risk
         s.add(u); s.commit()
+    ctx.user_data.clear()
     await update.message.reply_text(
         f"Готово.\nАванс: {u.advance_day}\nЗарплата: {u.salary_day}\n"
-        f"Коридор: {u.min_contrib}-{u.max_contrib} ₽\nРиск: {u.risk}\n\n"
+        f"Коридор: {fmt_amount(u.min_contrib)}-{fmt_amount(u.max_contrib)} ₽\nРиск: {u.risk}\n\n"
         "В нужные дни спрошу про доход и предложу распределение.",
         reply_markup=MAIN_KB
     )
-    return -1  # ConversationHandler.END
+    return ConversationHandler.END
+
+async def setup_cancel(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
+    ctx.user_data.clear()
+    await update.message.reply_text(
+        "Настройка прервана. Можно вернуться к меню или снова запустить /setup.",
+        reply_markup=MAIN_KB
+    )
+    return ConversationHandler.END
 
 # --- Обработчики кнопок главного меню
 async def on_text(update: Update, ctx: ContextTypes.DEFAULT_TYPE):
-    txt = update.message.text
-    if txt == "Статус":
-        with SessionLocal() as s:
-            u = s.get(User, update.effective_user.id)
-            if not u: return await update.message.reply_text("Сначала /start")
+    txt = (update.message.text or "").strip()
+    mode = ctx.user_data.get("mode")
+
+    if txt == CANCEL_BTN:
+        if mode:
+            ctx.user_data.pop("mode", None)
             return await update.message.reply_text(
-                f"Аванс: {u.advance_day}\nЗарплата: {u.salary_day}\n"
-                f"Взносы: {u.min_contrib}-{u.max_contrib} ₽\nРиск: {u.risk}",
-                reply_markup=MAIN_KB
+                "Отменил. Возвращаюсь к меню.",
+                reply_markup=MAIN_KB,
             )
-    if txt == "Сменить риск":
-        kb = ReplyKeyboardMarkup([["conservative","balanced","aggressive"]], resize_keyboard=True)
-        return await update.message.reply_text("Выбери риск-профиль:", reply_markup=kb)
-    if txt in {"conservative","balanced","aggressive"}:
-        with SessionLocal() as s:
-            u = s.get(User, update.effective_user.id)
-            if not u: return await update.message.reply_text("Сначала /start")
-            u.risk = txt; s.commit()
-        return await update.message.reply_text(f"Риск-профиль обновлён: {txt}", reply_markup=MAIN_KB)
-    if txt == "Внести взнос":
-        return await update.message.reply_text("Введи сумму взноса, ₽:")
-    # если это число — трактуем как взнос
-    try:
-        amount = float(txt.replace(" ", ""))
-        with SessionLocal() as s:
-            u = s.get(User, update.effective_user.id)
-            if not u: return await update.message.reply_text("Сначала /start")
-            s.add(Contribution(user_id=u.user_id, date=date.today(), amount=amount, source="manual")); s.commit()
-            target, plan = propose_allocation(amount, u.risk)
-        lines = "\n".join(f"- {k}: {v:,.0f} ₽".replace(",", " ") for k, v in plan.items())
         return await update.message.reply_text(
-            f"Зачислил {amount:,.0f} ₽.\nЦель: {target}\nРаспределение:\n{lines}",
-            reply_markup=MAIN_KB
+            "Хорошо, ничего не делаем.",
+            reply_markup=MAIN_KB,
         )
-    except Exception:
-        return await update.message.reply_text("Не понял. Используй меню или введи сумму, ₽.", reply_markup=MAIN_KB)
+
+    if txt == "Статус":
+        ctx.user_data.pop("mode", None)
+        with SessionLocal() as s:
+            u = s.get(User, update.effective_user.id)
+            if not u:
+                return await update.message.reply_text("Сначала /start", reply_markup=MAIN_KB)
+            total = (
+                s.query(func.sum(Contribution.amount))
+                .filter(Contribution.user_id == u.user_id)
+                .scalar()
+                or 0.0
+            )
+        return await update.message.reply_text(
+            f"Аванс: {u.advance_day}\nЗарплата: {u.salary_day}\n"
+            f"Взносы: {fmt_amount(u.min_contrib)}-{fmt_amount(u.max_contrib)} ₽\n"
+            f"Риск: {u.risk}\nТекущий баланс: {fmt_amount(total)} ₽",
+            reply_markup=MAIN_KB,
+        )
+
+    if txt == "Сменить риск":
+        ctx.user_data["mode"] = "risk"
+        return await update.message.reply_text(
+            "Выбери риск-профиль или нажми «Отмена».",
+            reply_markup=RISK_KB,
+        )
+
+    if txt in RISK_CHOICES:
+        with SessionLocal() as s:
+            u = s.get(User, update.effective_user.id)
+            if not u:
+                ctx.user_data.pop("mode", None)
+                return await update.message.reply_text("Сначала /start", reply_markup=MAIN_KB)
+            u.risk = txt
+            s.commit()
+        ctx.user_data.pop("mode", None)
+        return await update.message.reply_text(
+            f"Риск-профиль обновлён: {txt}",
+            reply_markup=MAIN_KB,
+        )
+
+    if mode == "risk":
+        return await update.message.reply_text(
+            "Пожалуйста, выбери одну из кнопок или нажми «Отмена».",
+            reply_markup=RISK_KB,
+        )
+
+    if txt == "Внести взнос":
+        ctx.user_data["mode"] = "contrib"
+        return await update.message.reply_text(
+            "Введи сумму взноса, ₽. Для отмены нажми «Отмена».",
+            reply_markup=CONTRIB_KB,
+        )
+
+    normalized = txt.replace(" ", "").replace(",", ".")
+    try:
+        amount = float(normalized)
+    except ValueError:
+        amount = None
+
+    if amount is not None and amount > 0:
+        with SessionLocal() as s:
+            u = s.get(User, update.effective_user.id)
+            if not u:
+                ctx.user_data.pop("mode", None)
+                return await update.message.reply_text("Сначала /start", reply_markup=MAIN_KB)
+            s.add(
+                Contribution(
+                    user_id=u.user_id,
+                    date=date.today(),
+                    amount=amount,
+                    source="manual",
+                )
+            )
+            s.commit()
+            total = (
+                s.query(func.sum(Contribution.amount))
+                .filter(Contribution.user_id == u.user_id)
+                .scalar()
+                or 0.0
+            )
+            target, plan = propose_allocation(amount, u.risk)
+        lines = "\n".join(f"- {k}: {fmt_amount(v)} ₽" for k, v in plan.items())
+        ctx.user_data.pop("mode", None)
+        return await update.message.reply_text(
+            f"Зачислил {fmt_amount(amount)} ₽.\nЦель: {target}\nРаспределение:\n{lines}\n"
+            f"Текущий баланс: {fmt_amount(total)} ₽",
+            reply_markup=MAIN_KB,
+        )
+
+    if mode == "contrib":
+        return await update.message.reply_text(
+            "Нужна сумма в рублях. Попробуй ещё раз или нажми «Отмена».",
+            reply_markup=CONTRIB_KB,
+        )
+
+    return await update.message.reply_text(
+        "Не понял. Используй меню или введи сумму, ₽.",
+        reply_markup=MAIN_KB,
+    )
 
 # Старые команды оставляем, если привык:
 async def setup2(update: Update, ctx: ContextTypes.DEFAULT_TYPE):  # совместимость

--- a/app/main.py
+++ b/app/main.py
@@ -3,7 +3,7 @@ from .config import settings
 from .db import engine, Base
 from .handlers import (
     start, setup_start, setup_adv_day, setup_sal_day, setup_min, setup_max, setup_risk,
-    on_text, setup2, income, contrib, status, risk
+    setup_cancel, on_text, setup2, income, contrib, status, risk
 )
 from .scheduler import setup_jobs
 from .handlers import ADV_DAY, SAL_DAY, MIN_AMT, MAX_AMT, RISK as RISK_STATE
@@ -22,7 +22,7 @@ def build_app() -> Application:
             MAX_AMT: [MessageHandler(filters.TEXT & ~filters.COMMAND, setup_max)],
             RISK_STATE: [MessageHandler(filters.TEXT & ~filters.COMMAND, setup_risk)],
         },
-        fallbacks=[]
+        fallbacks=[CommandHandler("cancel", setup_cancel)]
     ))
 
     # Совместимость старых команд

--- a/app/models.py
+++ b/app/models.py
@@ -1,4 +1,4 @@
-from sqlalchemy import Column, Integer, String, Date, Float, Boolean
+from sqlalchemy import Column, Integer, String, Date, Float
 from .db import Base
 
 class User(Base):
@@ -9,7 +9,6 @@ class User(Base):
     min_contrib = Column(Integer, default=40000)
     max_contrib = Column(Integer, default=50000)
     risk = Column(String, default="balanced")
-    got_salary = Column(Boolean, default=False)
 
 class Contribution(Base):
     __tablename__ = "contribs"

--- a/app/scheduler.py
+++ b/app/scheduler.py
@@ -11,16 +11,16 @@ def setup_jobs(app: Application, tz: str):
 
     @sch.scheduled_job(CronTrigger(hour=10, minute=0))
     async def ping_income_days():
-        today = datetime.now().day
+        today = datetime.now(sch.timezone).day
         with SessionLocal() as s:
             users = s.query(User).all()
             for u in users:
                 if today in (u.advance_day, u.salary_day):
                     await app.bot.send_message(
                         u.user_id,
-                        "Сегодня день выплаты (аванс/зарплата). Получил доход? Ответь:\n"
-                        "/income salary <сумма>  или  /income advance <сумма>\n"
-                        "После — внеси любую часть: /contrib <сумма>."
+                        "Сегодня день выплаты (аванс/зарплата). Получил доход?"
+                        " Открой бот, нажми «Внести взнос» и введи сумму — я предложу распределение."
+                        " Если параметры поменялись, запусти /setup."
                     )
 
     @sch.scheduled_job(CronTrigger(day="15", hour=11, minute=0))
@@ -29,8 +29,12 @@ def setup_jobs(app: Application, tz: str):
             users = s.query(User).all()
             for u in users:
                 target, plan = propose_allocation((u.min_contrib + u.max_contrib)/2, u.risk)
-                text = "Напоминание про взнос. Цель: " + target + "\n" + \
-                       "\n".join(f"- {k}: {v:,.0f} ₽".replace(",", " ") for k, v in plan.items())
+                lines = "\n".join(f"- {k}: {v:,.0f} ₽".replace(",", " ") for k, v in plan.items())
+                text = (
+                    "Напоминание про взнос. "
+                    f"Цель: {target}\n{lines}\n"
+                    "Когда будешь готов, нажми «Внести взнос» и введи сумму."
+                )
                 await app.bot.send_message(u.user_id, text)
 
     sch.start()

--- a/app/strategy.py
+++ b/app/strategy.py
@@ -1,20 +1,35 @@
+from decimal import Decimal, ROUND_HALF_UP, ROUND_DOWN
 from .providers import get_key_rate
 
 def propose_allocation(amount: float, risk: str):
+    def normalize(alloc: dict[str, float]) -> dict[str, float]:
+        alloc = {k: max(v, 0.0) for k, v in alloc.items()}
+        total = sum(alloc.values())
+        if not total:
+            return alloc
+        return {k: v / total for k, v in alloc.items()}
+
+    def apply_rate_shift(alloc: dict[str, float], increase_key: str, decrease_key: str,
+                         kr_percent: float, baseline: float, sensitivity: float) -> dict[str, float]:
+        shift = max(min((kr_percent - baseline) * sensitivity, 0.05), -0.05)
+        alloc[increase_key] = alloc.get(increase_key, 0.0) + shift
+        alloc[decrease_key] = alloc.get(decrease_key, 0.0) - shift
+        return normalize(alloc)
+
     r = risk
     kr = get_key_rate()
+    kr_percent = kr * 100 if kr <= 1 else kr
 
     if r == "conservative":
-        # цель ~12–17%
         alloc = {
             "ОФЗ/корп облигации": 0.55,
             "Дивидендные акции РФ": 0.20,
             "Фонды денежного рынка": 0.15,
             "Золото (БПИФ)": 0.10,
         }
-        target = "≈12–17% годовых"
+        alloc = apply_rate_shift(alloc, "ОФЗ/корп облигации", "Дивидендные акции РФ", kr_percent, 11.0, 0.01)
+        target = f"≈12–17% годовых при ключевой ставке {kr_percent:.1f}%"
     elif r == "aggressive":
-        # цель ~20–25%
         alloc = {
             "Акции роста РФ/друж. рынки": 0.50,
             "Дивидендные акции РФ": 0.15,
@@ -23,9 +38,9 @@ def propose_allocation(amount: float, risk: str):
             "Корп облигации (ВДО)": 0.10,
             "Кэш/Денежный рынок": 0.05,
         }
-        target = "≈20–25% годовых"
+        alloc = apply_rate_shift(alloc, "Корп облигации (ВДО)", "Акции роста РФ/друж. рынки", kr_percent, 11.5, 0.006)
+        target = f"≈20–25% годовых при ключевой ставке {kr_percent:.1f}%"
     else:
-        # цель ~18–20%
         alloc = {
             "Акции РФ (смешанные)": 0.35,
             "Дивидендные акции": 0.20,
@@ -33,7 +48,28 @@ def propose_allocation(amount: float, risk: str):
             "Золото (БПИФ)": 0.10,
             "Крипто (BTC/ETH)": 0.10,
         }
-        target = "≈18–20% годовых"
+        alloc = apply_rate_shift(alloc, "ОФЗ/корп облигации", "Акции РФ (смешанные)", kr_percent, 11.0, 0.008)
+        target = f"≈18–20% годовых при ключевой ставке {kr_percent:.1f}%"
 
-    plan = {k: round(v * amount) for k, v in alloc.items()}
+    total_amount = int(Decimal(str(amount)).quantize(Decimal("1"), rounding=ROUND_HALF_UP))
+    raw_values = [(name, Decimal(str(share)) * Decimal(total_amount)) for name, share in alloc.items()]
+    plan = {name: int(value.to_integral_value(rounding=ROUND_DOWN)) for name, value in raw_values}
+    remainder = total_amount - sum(plan.values())
+
+    if remainder > 0:
+        raw_values.sort(key=lambda x: x[1] - Decimal(plan[x[0]]), reverse=True)
+        for name, _ in raw_values:
+            if remainder <= 0:
+                break
+            plan[name] += 1
+            remainder -= 1
+    elif remainder < 0:
+        raw_values.sort(key=lambda x: x[1] - Decimal(plan[x[0]]))
+        for name, _ in raw_values:
+            if remainder >= 0:
+                break
+            if plan[name] > 0:
+                plan[name] -= 1
+                remainder += 1
+
     return target, plan


### PR DESCRIPTION
## Summary
- keep the /setup conversation in the correct step on invalid input, clear temporary data, and add a /cancel fallback
- align scheduled reminders with the button-based flow and respect the configured timezone
- update allocation calculations to react to the key rate, keep rounding consistent with the entered amount, and remove the unused got_salary field
- show the current balance in status and contribution replies, and add cancel buttons for risk changes and manual deposits

## Testing
- python -m compileall app

------
https://chatgpt.com/codex/tasks/task_b_68d09da542d08332a4d946e501bb0c56